### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:sid
+
+ENV LANG C.UTF-8
+ENV USER root
+ENV HOME /cloudfail
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+
+RUN apt-get install -yq python3-pip
+
+COPY . $HOME
+
+WORKDIR $HOME
+
+RUN pip3 install -r requirements.txt
+
+ENTRYPOINT ["python3", "cloudfail.py"]


### PR DESCRIPTION
Hello!

I'm often working with servers or other systems where Docker is installed, and to make my life a bit easier I made myself a Dockerfile for CloudFail. I figured maybe this would help someone else, so I decided to submit a Pull Request.

To Build the container:
`docker build -t cloudfail .`

And to run it:
`docker run -it cloudfail --target TARGET`

If you have any questions, let me know! Happy New Year!