### PR TITLE
Remove undefined name net_exc

### DIFF
--- a/cloudfail.py
+++ b/cloudfail.py
@@ -270,7 +270,7 @@ if args.tor is True:
         print_out(Fore.WHITE + Style.BRIGHT + "New IP: " + tor_ip)
 
     except requests.exceptions.RequestException as e:
-        print(e, net_exc)
+        print(e)
         sys.exit(0)
 
 if args.update is True:


### PR DESCRIPTION
`net_exc` is an _undefined name_ in this context because it is not defined or imported.  Executing this line of code will raise NameError which will block the printing of the real exception.