### PR TITLE
Added timeout feature for requests.

### DIFF
--- a/cloudfail.py
+++ b/cloudfail.py
@@ -167,7 +167,7 @@ def inCloudFlare(ip):
         return False
 
 
-def subdomain_scan(target, subdomains):
+def subdomain_scan(target, subdomains, timeout):
     i = 0
     c = 0
     if subdomains:
@@ -187,7 +187,7 @@ def subdomain_scan(target, subdomains):
 
                 subdomain = "{}.{}".format(word.strip(), target)
                 try:
-                    target_http = requests.get("http://"+subdomain)
+                    target_http = requests.get("http://"+subdomain, timeout=timeout)
                     target_http = str(target_http.status_code)
                     ip = socket.gethostbyname(subdomain)
                     ifIpIsWithin = inCloudFlare(ip)
@@ -244,7 +244,8 @@ logo = """\
 
 """
 
-print(Fore.RED + Style.BRIGHT + logo + Fore.RESET)
+DEFAULT_TIMEOUT = 5
+print(Fore.BLUE + Style.BRIGHT + logo + Fore.RESET)
 datestr = str(datetime.datetime.strftime(datetime.datetime.now(), '%d/%m/%Y'))
 print_out("Initializing CloudFail - the date is: " + datestr)
 
@@ -253,6 +254,8 @@ parser.add_argument("-t", "--target", help="target url of website", type=str)
 parser.add_argument("-T", "--tor", dest="tor", action="store_true", help="enable TOR routing")
 parser.add_argument("-u", "--update", dest="update", action="store_true", help="update databases")
 parser.add_argument("-s", "--subdomains", help="name of alternate subdomains list stored in the data directory", type=str)
+parser.add_argument("-d", "--timeout", help="timeout duration for requests with default being 5 seconds", type=int)
+
 parser.set_defaults(tor=False)
 parser.set_defaults(update=False)
 
@@ -276,6 +279,7 @@ if args.tor is True:
 if args.update is True:
     update()
 
+timeout = args.timeout if args.timeout else DEFAULT_TIMEOUT
 try:
 
     # Initialize CloudFail
@@ -288,7 +292,7 @@ try:
     crimeflare(args.target)
 
     # Scan subdomains with or without TOR
-    subdomain_scan(args.target, args.subdomains)
+    subdomain_scan(args.target, args.subdomains, timeout)
 
 except KeyboardInterrupt:
     sys.exit(0)


### PR DESCRIPTION
Some of the sites I was testing was taking too much time by CloudFail. I traced out the culprit which was the _Exception_ thrown:
> Failed to establish a new connection: [Errno 60] Operation timed out'))
which occurs due to default timeout behavior used in requests. So, the process would be stuck on a particular subdomain request for a long time then resume after the exception is thrown. 
This PR adds an optional timeout argument chosen by the user and also a default timeout of 5 sec if not given.
Hence, In this way CloudFail won't be stuck on any subdomain and also users will have the option to alter the timeout rather than the rigid hardcoded value.
