### PR TITLE
Update cloudfail.py for Python 3.8.5

### DIFF
--- a/cloudfail.py
+++ b/cloudfail.py
@@ -174,12 +174,12 @@ def check_for_wildcard(target):
     #Unsure how exactly I should test, for now simple appending to target. Don't know how to extract only domain to append *. for wildcard test
     try:
         #Throws exception if none found
-        answer = resolver.query('*.' + target)
+        answer = resolver.resolve('*.' + target)
         #If found, ask user if continue as long until valid answer
         choice = ''
-        while choice is not 'y' and choice is not 'n':
+        while choice != 'y' and choice != 'n':
             choice = input("A wildcard DNS entry was found. This will result in all subdomains returning an IP. Do you want to scan subdomains anyway? (y/n): ")
-        if choice is 'y':
+        if choice == 'y':
             return False
         else:
             return True


### PR DESCRIPTION
Update to #27 running under Python 3.8.5 on Ubuntu 20.04.1 LTS

cloudfail.py:177: DeprecationWarning: please use dns.resolver.Resolver.resolve() instead

# Changed query() to resolve()

cloudfail.py:180: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  while choice is not 'y' and choice is not 'n':
cloudfail.py:180: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  while choice is not 'y' and choice is not 'n':
cloudfail.py:182: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if choice is 'y':

# Changed the above "is not" to != and "is" to ==

Don't have a wildcarded cloudflare domain to check, but doesn't generate any further warnings